### PR TITLE
Invoke callback on login failure

### DIFF
--- a/android/src/main/java/com/dooboolab/naverlogin/RNNaverLoginModule.java
+++ b/android/src/main/java/com/dooboolab/naverlogin/RNNaverLoginModule.java
@@ -105,7 +105,9 @@ public class RNNaverLoginModule extends ReactContextBaseJavaModule {
                   } else {
                     String errCode = mOAuthLoginModule.getLastErrorCode(reactContext).getCode();
                     String errDesc = mOAuthLoginModule.getLastErrorDesc(reactContext);
-                    Log.e(TAG, "errCode: " + errCode + ", errDesc: " + errDesc);
+                    String message = "errCode: " + errCode + ", errDesc: " + errDesc;
+                    Log.e(TAG, message);
+                    cb.invoke(message, null);
                   }
                 }
               }


### PR DESCRIPTION
Before this commit, when initiating the login procedure but canceling
immediately, the callback wasn't invoked. This has been fixed with this commit.