### PR TITLE
Update RNNaverLogin.podspec

### DIFF
--- a/ios/RNNaverLogin.podspec
+++ b/ios/RNNaverLogin.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   RNNaverLogin
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://github.com/react-native-seoul/react-native-naver-login"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@domain.cn" }

--- a/ios/RNNaverLogin.podspec
+++ b/ios/RNNaverLogin.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   RNNaverLogin
                    DESC
-  s.homepage     = "https://github.com/react-native-seoul/react-native-naver-login"
+  s.homepage     = "https://github.com/react-native-seoul/react-native-naver-login.git"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@domain.cn" }


### PR DESCRIPTION
RNNaverLogin.podspec 파일을 업데이트 했습니다.

RN 0.61.1에서 pod install 중 다음과 같은 오류가 생겨 파일을 수정했습니다.

![image](https://user-images.githubusercontent.com/49827449/65769008-8032ab80-e16d-11e9-84d6-13190e449361.png)


아래는 제가 테스트한 환경입니다.
System:
OS: macOS Mojave 10.14.6
CPU: (12) x64 Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
Memory: 56.40 MB / 16.00 GB
Shell: 5.3 - /bin/zsh
Binaries:
Node: 12.5.0 - /usr/local/bin/node
npm: 6.11.3 - /usr/local/bin/npm
Watchman: 4.9.0 - /usr/local/bin/watchman
SDKs:
iOS SDK:
Platforms: iOS 12.4, macOS 10.14, tvOS 12.4, watchOS 5.3
IDEs:
Android Studio: 3.4 AI-183.6156.11.34.5522156
Xcode: 10.3/10G8 - /usr/bin/xcodebuild
npmPackages:
react: 16.8.1 => 16.8.1
react-native: 0.61.1 => 0.61.1
npmGlobalPackages:
react-native-cli: 2.0.1
react-native-create-library: 3.1.2