### PR TITLE
Bump Android build tool version, naverlogin-android-sdk

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 apply plugin: 'com.android.library'
 
 def DEFAULT_COMPILE_SDK_VERSION = 27
-def DEFAULT_BUILD_TOOLS_VERSION = "27.0.3"
+def DEFAULT_BUILD_TOOLS_VERSION = "29.0.2"
 def DEFAULT_MIN_SDK_VERSION = 16
 def DEFAULT_TARGET_SDK_VERSION = 26
 
@@ -36,5 +36,5 @@ repositories {
 
 dependencies {
   compile 'com.facebook.react:react-native:+'
-  implementation 'com.naver.nid:naveridlogin-android-sdk:4.2.5'
+  implementation 'com.naver.nid:naveridlogin-android-sdk:4.2.6'
 }


### PR DESCRIPTION
## Description
I bumped the *Android build tool* version and the `Naver` Android SDK version for preventing `user_cancling` error is invoked when the `Naver` app is not installed in user's phone.

[Naver developer QnA](https://developers.naver.com/forum/posts/28706)

## Works

- Bump Android build tool version `27.0.3` -> `29.0.2`
- Bump `com.naver.nid:naveridlogin-android-sdk` `4.2.5` -> `4.2.6`

## Linked issue

close #69