### PR TITLE
[fix] Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,10 +96,15 @@ React Native 네이버 로그인 라이브러리 입니다. 자세한 예제는 
 
 RN >= 0.60에서는 Autolinking이 지원되어 proguard를 제외한 별도의 설정이 필요하지 않습니다.
 
-1. Open up `android/app/src/main/java/[...]/MainActivity.java`
+1. Open up `android/app/src/main/java/[...]/MainApplication.java`
 
 - Add `import com.dooboolab.naverlogin.RNNaverLoginPackage;` to the imports at the top of the file
 - Add `new RNNaverLoginPackage()` to the list returned by the `getPackages()` method
+
+  ```java
+  List<ReactPackage> packages = new PackageList(this).getPackages();
+  packages.add(new RNNaverLoginPackage());
+  ```
 
 2. Append the following lines to `android/settings.gradle`:
 


### PR DESCRIPTION
resolves #81 

- Android 설명의 MainActivity.java 오타를 MainApplication.java으로 변경
- RNNaverLoginPackage 인스턴스를 getPackages() return list에 add하는 예시 코드 추가