### PR TITLE
네이버 로그인 중 유저가 취소한 경우에 대한 처리 추가 (iOS)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2,10 +2,18 @@ import { NativeModules, Platform } from "react-native";
 
 const { IosNaverLogin, RNNaverLogin } = NativeModules; // 여기 이름은 달라야 함.
 
-// const getNaverProfile = {}
+export const UserCancelErrorCode = {
+  android: 'user_cancel',
+  iOS: 2
+};
+
+export interface NaverLoginError extends Error {
+  errCode?: number | string;
+  errDesc?: string;
+}
 
 export interface ICallback<T> {
-  (error: Error | undefined, result: T | undefined): void;
+  (error: NaverLoginError | undefined, result: T | undefined): void;
 }
 
 export interface TokenResponse {

--- a/ios/IosNaverLogin.m
+++ b/ios/IosNaverLogin.m
@@ -61,6 +61,14 @@
     NSLog(@" \n\n\n Nearo oauth20ConnectionDidFinishDeleteToken \n\n\n");
 }
 
+- (void)oauth20Connection:(NaverThirdPartyLoginConnection *)oauthConnection didFailAuthorizationWithRecieveType:(THIRDPARTYLOGIN_RECEIVE_TYPE)receiveType
+{
+    NSLog(@"Getting auth code from NaverApp failed!");
+    if (naverTokenSend != nil) {
+        naverTokenSend(@[@{@"errCode": [[NSNumber alloc] initWithInt:receiveType]}, [NSNull null]]);
+    }
+}
+
 ////////////////////////////////////////////////////     _//////////_//      EXPORT_MODULE
 RCT_EXPORT_MODULE();
 


### PR DESCRIPTION
## PR 설명
네이버 로그인 중 유저가 취소했을 때 iOS의 경우 callback이 호출되지 않아 에러처리에 어려움이 있습니다. (#62)
해당 문제를 해결하기 위한 PR입니다.

## 변경점
- native
  - iOS 에러 발생 시 에러코드를 담아 callback 호출
- JS
  - Error interface 재정의 (errCode 및 errDesc 포함)
  - UserCancelErrorCode object 정의 (안드로이드와 iOS 에러코드가 다르기 때문에 각각 정의)