### PR TITLE
fix: iOS 빌드 에러 수정 - NidOAuth 초기화 파라미터 누락

### DIFF
--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -75,14 +75,11 @@ const modifyContentSwift = (contents: string, urlScheme: string) => {
 ${NAVER_HEADER_IMPORT_STRING_SWIFT}`
     );
   }
-  // Add NidOAuth initialization in didFinishLaunchingWithOptions
-  if (!contents.includes('NidOAuth.shared.initialize()')) {
-    contents = contents.replace(
-      'return super.application(application, didFinishLaunchingWithOptions: launchOptions)',
-      `    NidOAuth.shared.initialize()
-    return super.application(application, didFinishLaunchingWithOptions: launchOptions)`
-    );
-  }
+  // Note: NidOAuth initialization is not needed in AppDelegate.
+  // The library handles initialization through NaverLogin.initialize() called from JavaScript.
+  // The newer versions of NidThirdPartyLogin SDK require parameters (appName, clientId, clientSecret, urlScheme),
+  // but these are properly managed by the JavaScript layer when calling NaverLogin.initialize().
+  // Removing this to prevent build errors with SDK updates.
 
   // Add URL handling for Naver login
   if (!contents.includes('NidOAuth.shared.handle')) {


### PR DESCRIPTION
## 문제
#229 

iOS 빌드 시 다음 에러가 발생합니다:
```
error: missing arguments for parameters 'appName', 'clientId', 'clientSecret', 'urlScheme' in call
NidOAuth.shared.initialize()
```

최신 `NidThirdPartyLogin` SDK가 업데이트되면서 `initialize()` 메서드에 필수 파라미터가 추가되었는데, Expo config plugin이 여전히 파라미터 없이 호출하고 있어서 발생하는 문제입니다.

## 변경사항
- `plugin/src/index.ts`에서 파라미터 없는 `NidOAuth.shared.initialize()` 주입 코드 제거

## 테스트
- ✅ SDK 54 & React Native 0.81에서 iOS 빌드 성공
- ✅ 네이버 로그인 정상 작동
- ✅ 기존 API에 변경사항 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized authentication initialization process by centralizing configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->